### PR TITLE
Typechecking for let-expressions

### DIFF
--- a/src/edu/sjsu/stratagem/Expression.java
+++ b/src/edu/sjsu/stratagem/Expression.java
@@ -194,9 +194,14 @@ class FunctionDeclExpr implements Expression {
             innerEnv.createVar(paramNames[i], paramTypes[i]);
         }
         Type bodyT = body.typecheck(innerEnv);
-        if (!bodyT.equals(returnType)) {
-            throw new StratagemTypecheckException(
-                    "Function's body doesn't have ascribed type, ascribed: " + returnType + ", had: " + bodyT);
+        if (returnType == null) {
+            // Infer the type for function body based on what we found.
+            returnType = bodyT;
+        } else {
+            if (!bodyT.equals(returnType)) {
+                throw new StratagemTypecheckException(
+                        "Function's body doesn't have ascribed type, ascribed: " + returnType + ", had: " + bodyT);
+            }
         }
         return new ClosureType(paramTypes[0], returnType);
     }

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -120,10 +120,7 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
 		paramNames.add(id);
 		paramTypes.add(parseType(ctx.type()));
 
-		// FIXME: Need to determine return type somehow. Add an explicit annotation in the grammar?
-		Type returnType = null;
-
-		FunctionDeclExpr implicitDecl = new FunctionDeclExpr(paramNames, paramTypes, returnType, body);
+		FunctionDeclExpr implicitDecl = new FunctionDeclExpr(paramNames, paramTypes, null, body);
 
 		List<Expression> args = new ArrayList<>();
 		args.add(value);

--- a/stratagemScripts/examples.strata
+++ b/stratagemScripts/examples.strata
@@ -1,4 +1,4 @@
 let x: Int = 0 in x + 1;
 let x: Int = 3 + 4 in x;
 let y: Bool = true in ();
-fn(z: Bool): Bool { z; z }(false)
+fn(z: Bool): Bool { z; z }(let b: Bool = true in b)


### PR DESCRIPTION
Use type inference to determine the type of let-expression bodies.

Type inference is induced when a FunctionDeclExpr is constructed with a returnType of null.

Fixes #4.