### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+install:
+  - mkdir lib
+  - (cd lib; curl -OL http://www.antlr.org/download/antlr-4.6-complete.jar)
+  - (cd lib; curl -OL 'http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar')
+  - (cd lib; curl -OL 'http://search.maven.org/remotecontent?filepath=junit/junit/4.12/junit-4.12.jar')
+
+script:
+  - make
+
+after_success:
+  - make test
+  - make run
+


### PR DESCRIPTION
Travis CI is a free (for open source GitHub projects) continuous integration service.

Adding this file will tell Travis CI how to run our JUnit tests and sample Stratagem scripts. After this PR is merged we need to turn Travis on for this repository. @taustin, you'll have to be the one to do this since the repo is under your GitHub account. If you don't have an account with Travis, you'll need to make one for free.

Once this is done, we'll see the status of Travis's checks above the "Merge pull request" button that's normally on PRs. An example of what that looks like is here: https://github.com/pmer/stratagem/pull/1

Be default, Travis CI emails you a lot, so you might want to turn their email notifications off for this repo lest you like keeping tabs on the builds.