### PR TITLE
Add higher-order functions

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -69,7 +69,8 @@ prog: seq ;
 
 seq: expr (SEPARATOR expr)* ;
 
-expr: expr args                                                                   # functionApp
+expr: LPAREN expr RPAREN                                                          # parens
+    | expr args                                                                   # functionApp
     | FUNCTION params COLON type LBRACE seq RBRACE                                # functionDecl
     | LIT_INT                                                                     # int
     | LIT_BOOL                                                                    # bool

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -128,6 +128,11 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
     }
 
     @Override
+    public Expression visitParens(StratagemParser.ParensContext ctx) {
+        return visit(ctx.expr());
+    }
+
+    @Override
     public Expression visitPrint(StratagemParser.PrintContext ctx) {
         Expression arg = visit(ctx.args().getChild(1));
         return new PrintExpr(arg);


### PR DESCRIPTION
This adds support for type signatures like the following:

`let apply: (Int -> Int) -> (Int -> Int)`

This was originally added in #11, but I decided to split it out so we can look at the two features independently. This one should be easier to merge.

This also adds a test for it.