### PR TITLE
Add higher order functions

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -91,6 +91,7 @@ args: LPAREN expr RPAREN
 
 type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | UNIT ;
 
-type_fun  : type_prim TYPE_FUN type ;
+//          (domain                            ) TYPE_FUN codomain ;
+type_fun  : (type_prim | LPAREN type_fun RPAREN) TYPE_FUN type ;
 
 type      : type_prim | type_fun ;

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -187,7 +187,16 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
     }
 
     private Type parseClosureType(StratagemParser.Type_funContext ctx) {
-        Type arg = parsePrimitiveType(ctx.type_prim());
+        StratagemParser.Type_primContext prim = ctx.type_prim();
+        Type arg;
+
+        if (prim != null) {
+            arg = parsePrimitiveType(prim);
+        } else {
+            StratagemParser.Type_funContext fun = ctx.type_fun();
+            arg = parseClosureType(fun);
+        }
+
         Type ret = parseType(ctx.type());
         return new ClosureType(arg, ret);
     }

--- a/stratagemScripts/examples.strata
+++ b/stratagemScripts/examples.strata
@@ -1,3 +1,10 @@
 // Interesting examples
 
-0
+let apply: (Int -> Int) -> Int -> Int =
+    fn(f: Int -> Int): Int -> Int {
+        fn(n: Int): Int {
+            f(n)
+        }
+    }
+in let plusOne: Int -> Int = fn(n: Int): Int { n + 1 }
+in apply(plusOne)(2) == 3


### PR DESCRIPTION
Functions associate right, so

`(Int -> Int) -> (Int -> Int)`

is the same as

`(Int -> Int) -> Int -> Int`

just like in Haskell.

(This PR will cause merge conflicts with #11, but I'll rewrite #11 later.)