### PR TITLE
Replace () type and value with Unit and unit

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -10,19 +10,18 @@ ELSE     : 'else' ;
 LET      : 'let' ;
 
 // Literals
+LIT_UNIT   : 'unit' ;
 LIT_INT    : [1-9][0-9]* | '0' ;
 LIT_BOOL   : 'true' | 'false' ;
 LIT_STRING : '"' ( ESC | . )*? '"' ;
 fragment ESC : '\\' [tnr"\\] ;  // Matches: \t \n \r \" \\
 
 // Types
+TYPE_UNIT      : 'Unit' ;
 TYPE_INT       : 'Int' ;
 TYPE_BOOL      : 'Bool' ;
 TYPE_STRING    : 'String' ;
 TYPE_FUN       : '->' ;
-
-// Both a type and a literal
-UNIT      : '()' ;
 
 // Binary operators
 MUL       : '*' ;
@@ -75,7 +74,7 @@ expr: LPAREN expr RPAREN                                                        
     | LIT_INT                                                                     # int
     | LIT_BOOL                                                                    # bool
     | LIT_STRING                                                                  # string
-    | UNIT                                                                        # unit
+    | LIT_UNIT                                                                    # unit
     | ID                                                                          # id
     | IF LPAREN expr RPAREN LBRACE seq RBRACE ELSE LBRACE seq RBRACE              # if
     | LET ID COLON type ASSIGN expr IN expr                                       # let
@@ -89,7 +88,7 @@ params: LPAREN ID COLON type RPAREN
 args: LPAREN expr RPAREN
     ;
 
-type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | UNIT ;
+type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | TYPE_UNIT ;
 
 //          (domain                            ) TYPE_FUN codomain ;
 type_fun  : (type_prim | LPAREN type_fun RPAREN) TYPE_FUN type ;

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -179,7 +179,7 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
             return IntType.singleton;
         } else if (ctx.TYPE_STRING() != null) {
             return StringType.singleton;
-        } else if (ctx.UNIT() != null) {
+        } else if (ctx.TYPE_UNIT() != null) {
             return UnitType.singleton;
         } else {
             throw new StratagemException("Unknown primitive type");

--- a/stratagemScripts/expressions.strata
+++ b/stratagemScripts/expressions.strata
@@ -5,7 +5,7 @@
 true;
 2;
 "three";
-();
+unit;
 
 // Function declaration
 fn(n: Int): Int { 1 };

--- a/stratagemScripts/print.strata
+++ b/stratagemScripts/print.strata
@@ -2,4 +2,4 @@ print("string");  // string
 print(true);  // boolean
 print(fn(n: Int): Int { n + 1 });  // closure
 print(5 - 5);  // integer
-print(())  // unit
+print(unit)  // unit


### PR DESCRIPTION
Replacing symbols with words might make code a bit more readable.

For example, the following code, which has three sets of parentheses all
meaning different things:

```js
fn(): () { () }
```

would be written as

```js
fn(): Unit { unit }
```