### PR TITLE
Add dynamic Any type and add cast expressions

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -22,6 +22,7 @@ TYPE_INT       : 'Int' ;
 TYPE_BOOL      : 'Bool' ;
 TYPE_STRING    : 'String' ;
 TYPE_FUN       : '->' ;
+TYPE_ANY       : '?' ;
 
 // Binary operators
 MUL       : '*' ;
@@ -88,7 +89,7 @@ params: LPAREN ID COLON type RPAREN
 args: LPAREN expr RPAREN
     ;
 
-type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | TYPE_UNIT ;
+type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | TYPE_UNIT | TYPE_ANY ;
 
 //          (domain                            ) TYPE_FUN codomain ;
 type_fun  : (type_prim | LPAREN type_fun RPAREN) TYPE_FUN type ;

--- a/src/edu/sjsu/stratagem/Expression.java
+++ b/src/edu/sjsu/stratagem/Expression.java
@@ -217,7 +217,7 @@ class FunctionDeclExpr implements Expression {
             // Infer the type for function body based on what we found.
             returnType = bodyT;
         } else {
-            if (!bodyT.equals(returnType)) {
+            if (!bodyT.consistentWith(returnType)) {
                 throw new StratagemTypecheckException(
                         "Function's body doesn't have ascribed type, ascribed: " + returnType + ", had: " + bodyT);
             }

--- a/src/edu/sjsu/stratagem/Expression.java
+++ b/src/edu/sjsu/stratagem/Expression.java
@@ -257,15 +257,24 @@ class IfExpr implements Expression {
             throw new StratagemTypecheckException("If-expression expected boolean in condition, got: " + condT);
         }
 
-        // Cast insertion rule (CIf).
+        // Cast insertion rule (CIf1).
         if (condT == AnyType.singleton) {
             // Wrap the condition expression in a cast to ensure it is a boolean at runtime.
             cond = new CastExpr(BoolType.singleton, cond);
         }
 
         if (!thnT.equals(elsT)) {
-            throw new StratagemTypecheckException("If-expression branches have unequal type: " + thnT + " and " + elsT);
+            if (!thnT.consistentWith(elsT)) {
+                throw new StratagemTypecheckException(
+                        "If-expression branches have inconsistent types: " + thnT + " and " + elsT);
+            }
+
+            // Cast the right branch to the left.
+            // FIXME: Return the lowest possible type that's a supertype of both. (TIf, CIf2, CIF3)
+            els = new CastExpr(thnT, els);
         }
+
+        // Typing rule (TIf).
         return thnT;
     }
 

--- a/src/edu/sjsu/stratagem/Expression.java
+++ b/src/edu/sjsu/stratagem/Expression.java
@@ -33,6 +33,7 @@ class BinOpExpr implements Expression {
     private Op op;
     private Expression e1;
     private Expression e2;
+
     BinOpExpr(Op op, Expression e1, Expression e2) {
         this.op = op;
         this.e1 = e1;
@@ -71,19 +72,16 @@ class BinOpExpr implements Expression {
             return new BoolVal(v1.equals(v2));
         case NE:
             return new BoolVal(!v1.equals(v2));
-        case ADD:
-            // Specifically skipping cases where we have two numbers
-            if (!(v1 instanceof IntVal && v2 instanceof IntVal)) {
-                return new StringVal(v1.toString() + v2.toString());
-            }
         }
 
         // Int operations case
         if (!(v1 instanceof IntVal && v2 instanceof IntVal)) {
-            throw new StratagemRuntimeException("Expected ints, but got " + v1 + " and " + v2);
+            throw new StratagemCastException("Expected ints, but got " + v1 + " and " + v2);
         }
+
         int i = ((IntVal) v1).toInt();
         int j = ((IntVal) v2).toInt();
+
         switch(op) {
         case ADD:
             return new IntVal(i + j);

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -68,24 +68,17 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
     @Override
     public Expression visitFunctionApp(StratagemParser.FunctionAppContext ctx) {
         Expression f = visit(ctx.expr());
-        List<Expression> args = new ArrayList<>();
         Expression arg = visit(ctx.args().getChild(1));
-        args.add(arg);
-        return new FunctionAppExpr(f, args);
+        return new FunctionAppExpr(f, arg);
     }
 
     @Override
     public Expression visitFunctionDecl(StratagemParser.FunctionDeclContext ctx) {
-        List<String> paramNames = new ArrayList<>();
-        paramNames.add(ctx.params().ID().getText());
-
-        List<Type> paramTypes = new ArrayList<>();
-        paramTypes.add(parseType(ctx.params().type()));
-
+        String paramName = ctx.params().ID().getText();
+        Type paramType = parseType(ctx.params().type());
         Type returnType = parseType(ctx.type());
         Expression body = visit(ctx.seq());
-
-        return new FunctionDeclExpr(paramNames, paramTypes, returnType, body);
+        return new FunctionDeclExpr(paramName, paramType, returnType, body);
     }
 
     @Override
@@ -113,18 +106,10 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
         String id = ctx.ID().getText();
         Expression value = visit(ctx.expr(0));
         Expression body = visit(ctx.expr(1));
+        Type paramType = parseType(ctx.type());
 
-        List<String> paramNames = new ArrayList<>();
-        List<Type> paramTypes = new ArrayList<>();
-
-        paramNames.add(id);
-        paramTypes.add(parseType(ctx.type()));
-
-        FunctionDeclExpr implicitDecl = new FunctionDeclExpr(paramNames, paramTypes, null, body);
-
-        List<Expression> args = new ArrayList<>();
-        args.add(value);
-        return new FunctionAppExpr(implicitDecl, args);
+        FunctionDeclExpr implicitDecl = new FunctionDeclExpr(id, paramType, null, body);
+        return new FunctionAppExpr(implicitDecl, value);
     }
 
     @Override

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -166,6 +166,8 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
             return StringType.singleton;
         } else if (ctx.TYPE_UNIT() != null) {
             return UnitType.singleton;
+        } else if (ctx.TYPE_ANY() != null) {
+            return AnyType.singleton;
         } else {
             throw new StratagemException("Unknown primitive type");
         }

--- a/src/edu/sjsu/stratagem/Type.java
+++ b/src/edu/sjsu/stratagem/Type.java
@@ -10,6 +10,18 @@ public interface Type {}
 //can be included in the same file.
 
 /**
+ * Dynamic any type.
+ */
+class AnyType implements Type {
+    public static final AnyType singleton = new AnyType();
+
+    @Override
+    public String toString() {
+        return "?";
+    }
+}
+
+/**
  * Boolean types.
  */
 class BoolType implements Type {

--- a/src/edu/sjsu/stratagem/Type.java
+++ b/src/edu/sjsu/stratagem/Type.java
@@ -4,7 +4,9 @@ package edu.sjsu.stratagem;
  * Types in Stratagem.
  * Typechecking a Stratagem expression should return a Stratagem type.
  */
-public interface Type {}
+public interface Type {
+    boolean consistentWith(Type other);
+}
 
 //NOTE: Using package access so that all implementations of Type
 //can be included in the same file.
@@ -14,6 +16,10 @@ public interface Type {}
  */
 class AnyType implements Type {
     public static final AnyType singleton = new AnyType();
+
+    public boolean consistentWith(Type other) {
+        return true;
+    }
 
     @Override
     public String toString() {
@@ -27,6 +33,10 @@ class AnyType implements Type {
 class BoolType implements Type {
     public static final BoolType singleton = new BoolType();
 
+    public boolean consistentWith(Type other) {
+        return other instanceof BoolType || other instanceof AnyType;
+    }
+
     @Override
     public String toString() {
         return "Bool";
@@ -38,6 +48,10 @@ class BoolType implements Type {
  */
 class IntType implements Type {
     public static final IntType singleton = new IntType();
+
+    public boolean consistentWith(Type other) {
+        return other instanceof IntType || other instanceof AnyType;
+    }
 
     @Override
     public String toString() {
@@ -51,6 +65,10 @@ class IntType implements Type {
 class StringType implements Type {
     public static final StringType singleton = new StringType();
 
+    public boolean consistentWith(Type other) {
+        return other instanceof StringType || other instanceof AnyType;
+    }
+
     @Override
     public String toString() {
         return "String";
@@ -62,6 +80,10 @@ class StringType implements Type {
  */
 class UnitType implements Type {
     public static final UnitType singleton = new UnitType();
+
+    public boolean consistentWith(Type other) {
+        return other instanceof UnitType || other instanceof AnyType;
+    }
 
     @Override
     public String toString() {
@@ -91,13 +113,15 @@ class ClosureType implements Type {
         return ret;
     }
 
-    @Override
-    public boolean equals(Object that) {
-        if (!(that instanceof ClosureType)) {
+    public boolean consistentWith(Type other) {
+        if (other instanceof AnyType) {
+            return true;
+        }
+        if (!(other instanceof ClosureType)) {
             return false;
         }
-        ClosureType other = (ClosureType) that;
-        return arg.equals(other.arg) && ret.equals(other.ret);
+        ClosureType that = (ClosureType)other;
+        return arg.consistentWith(that.arg) && ret.consistentWith(that.ret);
     }
 
     @Override

--- a/src/edu/sjsu/stratagem/Type.java
+++ b/src/edu/sjsu/stratagem/Type.java
@@ -103,10 +103,8 @@ class ClosureType implements Type {
         this.ret = ret;
     }
 
-    public Type[] getArgTypes() {
-        return new Type[] {
-                arg
-        };
+    public Type getArgType() {
+        return arg;
     }
 
     public Type getReturnType() {

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -39,11 +39,8 @@ class BoolVal implements Value {
  * Note that a closure remembers its surrounding scope.
  */
 class ClosureVal implements Value {
-    private static final String[] stringArrayHint = new String[0];
-    private static final Type[] typeArrayHint = new Type[0];
-
-    private String[] paramNames;
-    private Type[] paramTypes;
+    private String paramName;
+    private Type paramType;
     private Type returnType;
     private Expression body;
     private ValueEnvironment outerEnv;
@@ -52,33 +49,22 @@ class ClosureVal implements Value {
      * The environment is the environment where the function was created.
      * This design is what makes this expression a closure.
      */
-    public ClosureVal(String[] paramNames, Type[] paramTypes, Type returnType, Expression body, ValueEnvironment outerEnv) {
-        this.paramNames = paramNames;
-        this.paramTypes = paramTypes;
-        this.returnType = returnType;
-        this.body = body;
-        this.outerEnv = outerEnv;
-    }
-
-    public ClosureVal(List<String> paramNames, List<Type> paramTypes, Type returnType, Expression body, ValueEnvironment outerEnv) {
-        this.paramNames = paramNames.toArray(stringArrayHint);
-        this.paramTypes = paramTypes.toArray(typeArrayHint);
+    public ClosureVal(String paramName, Type paramType, Type returnType, Expression body, ValueEnvironment outerEnv) {
+        this.paramName = paramName;
+        this.paramType = paramType;
         this.returnType = returnType;
         this.body = body;
         this.outerEnv = outerEnv;
     }
 
     public Type getType() {
-        return new ClosureType(paramTypes[0], returnType);
+        return new ClosureType(paramType, returnType);
     }
 
     public String toString() {
         StringBuilder s = new StringBuilder("function(");
         String sep = "";
-        for (int i = 0; i < paramNames.length; i++) {
-            s.append(sep).append(paramNames[i]).append(": ").append(paramTypes[i]);
-            sep = ", ";
-        }
+        s.append(sep).append(paramName).append(": ").append(paramType);
         s.append("): ").append(returnType).append(" {...}");
 
         return s.toString();
@@ -89,14 +75,9 @@ class ClosureVal implements Value {
      * of the environment where the function was created. Each parameter should
      * be bound to its matching argument and added to the new local environment.
      */
-    public Value apply(List<Value> argVals) {
-        assert argVals.size() == paramNames.length;
+    public Value apply(Value argVal) {
         ValueEnvironment newEnv = new ValueEnvironment(outerEnv);
-        for (int i = 0; i < argVals.size(); i++) {
-            String varName = paramNames[i];
-            Value v = argVals.get(i);
-            newEnv.createVar(varName, v);
-        }
+        newEnv.createVar(paramName, argVal);
         return body.evaluate(newEnv);
     }
 }

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -119,8 +119,7 @@ class StringVal implements Value {
     }
     @Override
     public String toString() {
-        //return "'" + this.s + "'";
-        return this.s;
+        return "\"" + this.s + "\"";
     }
 }
 

--- a/src/edu/sjsu/stratagem/exception/StratagemCastException.java
+++ b/src/edu/sjsu/stratagem/exception/StratagemCastException.java
@@ -1,0 +1,7 @@
+package edu.sjsu.stratagem.exception;
+
+public class StratagemCastException extends StratagemRuntimeException {
+    public StratagemCastException(String message) {
+        super(message);
+    }
+}

--- a/stratagemScripts/examples.strata
+++ b/stratagemScripts/examples.strata
@@ -7,4 +7,28 @@ let apply: (Int -> Int) -> Int -> Int =
         }
     }
 in let plusOne: Int -> Int = fn(n: Int): Int { n + 1 }
-in apply(plusOne)(2) == 3
+in apply(plusOne)(2) == 3;
+
+let fix: ? =
+    fn(f: ?): ? {
+        fn(x: ?): ? {
+            f(fn(y: ?): ? {
+                x(x)(y)
+            })
+        }(fn(x: ?): ? {
+            f(fn(y: ?): ? {
+                x(x)(y)
+            })
+        })
+    }
+in let fix_factorial: (Int -> Int) -> Int -> Int =
+    fn(f: Int -> Int): Int -> Int {
+        fn(n: Int): Int {
+            if (n == 0) {
+                1
+            } else {
+                n * f(n - 1)
+            }
+        }
+    }
+in fix(fix_factorial)(4)  // 24

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -94,36 +94,14 @@ public class ExpressionTest {
     // (function(x) { x; })(321);
     public void testIdFunction() {
         ValueEnvironment env = new ValueEnvironment();
-        List<String> paramNames = new ArrayList<>();
-        paramNames.add("x");
-        FunctionDeclExpr f = new FunctionDeclExpr(paramNames,
-                new ArrayList<>(),
+        FunctionDeclExpr f = new FunctionDeclExpr(
+                "x",
+                null,
                 null,
                 new VarExpr("x"));
-        List<Expression> args = new ArrayList<>();
-        args.add(new ValueExpr(new IntVal(321)));
-        FunctionAppExpr app = new FunctionAppExpr(f,args);
+        Expression arg = new ValueExpr(new IntVal(321));
+        FunctionAppExpr app = new FunctionAppExpr(f, arg);
         assertEquals(new IntVal(321), app.evaluate(env));
-    }
-
-    @Test
-    // (function(x,y) { x / y; })(8,2);
-    public void testDivFunction() {
-        ValueEnvironment env = new ValueEnvironment();
-        List<String> params = new ArrayList<>();
-        params.add("x");
-        params.add("y");
-        FunctionDeclExpr f = new FunctionDeclExpr(params,
-                new ArrayList<>(),
-                null,
-                new BinOpExpr(Op.DIVIDE,
-                        new VarExpr("x"),
-                        new VarExpr("y")));
-        List<Expression> args = new ArrayList<>();
-        args.add(new ValueExpr(new IntVal(8)));
-        args.add(new ValueExpr(new IntVal(2)));
-        FunctionAppExpr app = new FunctionAppExpr(f,args);
-        assertEquals(new IntVal(4), app.evaluate(env));
     }
 
     @Test
@@ -134,19 +112,17 @@ public class ExpressionTest {
 
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
-                new String[] {"unused"},
+                "unused",
                 null,
                 null,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
-                new String[] {"name"},
+                "name",
                 null,
                 null,
-                new FunctionAppExpr(innerDecl, new Expression[] { new ValueExpr(bob) }));
+                new FunctionAppExpr(innerDecl, new ValueExpr(bob)));
 
-        FunctionAppExpr outerApp = new FunctionAppExpr(
-                outerDecl,
-                new Expression[] { new ValueExpr(alice) });
+        FunctionAppExpr outerApp = new FunctionAppExpr(outerDecl, new ValueExpr(alice));
         Value v = outerApp.evaluate(env);
         assertEquals(v, alice);
     }
@@ -159,19 +135,19 @@ public class ExpressionTest {
 
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
-                new String[] {"name"},
+                "name",
                 null,
                 null,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
-                new String[] {"name"},
+                "name",
                 null,
                 null,
-                new FunctionAppExpr(innerDecl, new Expression[] { new ValueExpr(bob) }));
+                new FunctionAppExpr(innerDecl, new ValueExpr(bob)));
 
         FunctionAppExpr outerApp = new FunctionAppExpr(
                 outerDecl,
-                new Expression[] { new ValueExpr(alice) });
+                new ValueExpr(alice));
         Value v = outerApp.evaluate(env);
         assertEquals(v, bob);
     }
@@ -184,22 +160,22 @@ public class ExpressionTest {
 
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
-                new String[] {"name"},
+                "name",
                 null,
                 null,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
-                new String[] {"name"},
+                "name",
                 null,
                 null,
                 new SeqExpr(new Expression[] {
-                        new FunctionAppExpr(innerDecl, new Expression[] { new ValueExpr(bob) }),
+                        new FunctionAppExpr(innerDecl, new ValueExpr(bob)),
                         new VarExpr("name")
                 }));
 
         FunctionAppExpr outerApp = new FunctionAppExpr(
                 outerDecl,
-                new Expression[] { new ValueExpr(alice) });
+                new ValueExpr(alice));
         Value v = outerApp.evaluate(env);
         assertEquals(v, alice);
     }

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.sjsu.stratagem.exception.StratagemCastException;
 import edu.sjsu.stratagem.exception.StratagemException;
 import org.junit.Test;
 
@@ -180,13 +181,14 @@ public class ExpressionTest {
         assertEquals(v, alice);
     }
 
-    @Test
-    // "no" + "table"
-    public void testStringAppend() {
-        ValueEnvironment env = new ValueEnvironment();
-        Expression s1 = new ValueExpr(new StringVal("no"));
-        Expression s2 = new ValueExpr(new StringVal("table"));
-        Expression exp = new BinOpExpr(Op.ADD, s1, s2);
-        assertEquals(new StringVal("notable"), exp.evaluate(env));
+    // Produce an int value with type Any.
+    //   fn(n: Int): ? { val }
+    private Expression makeAny(int val) {
+        FunctionDeclExpr f = new FunctionDeclExpr(
+                "n",
+                IntType.singleton,
+                AnyType.singleton,
+                new VarExpr("n"));
+        return new FunctionAppExpr(f, new ValueExpr(new IntVal(val)));
     }
 }

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -191,4 +191,27 @@ public class ExpressionTest {
                 new VarExpr("n"));
         return new FunctionAppExpr(f, new ValueExpr(new IntVal(val)));
     }
+
+    @Test
+    // let n: ? = 1
+    // in fn(s: String): () { () }
+    //  throws StratagemCastException
+    public void testApplicationCastException() {
+        Expression n = makeAny(1);
+        FunctionDeclExpr f = new FunctionDeclExpr(
+                "s",
+                StringType.singleton,
+                UnitType.singleton,
+                new ValueExpr(UnitVal.singleton));
+        FunctionAppExpr app = new FunctionAppExpr(f, n);
+
+        app.typecheck(new TypeEnvironment());  // Insert cast that will fail.
+
+        try {
+            app.evaluate(new ValueEnvironment());
+        } catch (StratagemCastException e) {
+            return;  // pass
+        }
+        assertTrue("Failed to throw StratagemCastException", false);
+    }
 }


### PR DESCRIPTION
To the best of my knowledge, everything but the if-expressions should be working, although I have only done cursory testing so far!

Right now the if-expressions cast the right-hand branch to the left-hand branch's type if their types are unequal. This behavior is incorrect. The correct behavior is to cast both branches to the lowest type that is a supertype of both branches. With our limited type system, this only has an interesting interaction with function types, but it will also add complexity to records or objects once we get there. This if-expression behavior will also bring us in-line with TypeScript and most ad-hoc type inference algorithms, such as the one for Python in PyCharm, etc. Details can be found in issue #10.

Cast expressions cannot be inserted manually by the programmer—there is no grammar for them. Instead, they are inserted automatically at the right places during typechecking. You can find them in all the `typecheck()` functions inside Expression.java. This keeps us in line with the behavior Siek defined for his language.

Fixes #10.