### PR TITLE
Properly type check if-expressions in presence of the Any type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ script:
 after_success:
   - make test
   - make run
-

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ parse: generate compile ${TREES_DIR}
 test: generate compile
 	java -cp ${BUILD_DIR}:${TEST_CLASSPATH} \
 	     org.junit.runner.JUnitCore \
-	     ${PACKAGE_NAME}.ExpressionTest
+	     ${PACKAGE_NAME}.CastTest \
+	     ${PACKAGE_NAME}.ExpressionTest \
+	     ${PACKAGE_NAME}.ValueTest
 
 # Run the interpretor on all test Stratagem scripts
 run: generate compile

--- a/src/edu/sjsu/stratagem/Expression.java
+++ b/src/edu/sjsu/stratagem/Expression.java
@@ -348,6 +348,10 @@ class SeqExpr implements Expression {
  * Stratagem constants.
  */
 class ValueExpr implements Expression {
+    public static final ValueExpr unitSingleton = new ValueExpr(UnitVal.singleton);
+    public static final ValueExpr trueSingleton = new ValueExpr(BoolVal.trueSingleton);
+    public static final ValueExpr falseSingleton = new ValueExpr(BoolVal.falseSingleton);
+
     private Value val;
 
     ValueExpr(Value v) {

--- a/src/edu/sjsu/stratagem/Type.java
+++ b/src/edu/sjsu/stratagem/Type.java
@@ -6,6 +6,7 @@ package edu.sjsu.stratagem;
  */
 public interface Type {
     boolean consistentWith(Type other);
+    Type findSupertypeWith(Type other);
 }
 
 //NOTE: Using package access so that all implementations of Type
@@ -19,6 +20,10 @@ class AnyType implements Type {
 
     public boolean consistentWith(Type other) {
         return true;
+    }
+
+    public Type findSupertypeWith(Type other) {
+        return AnyType.singleton;
     }
 
     @Override
@@ -37,6 +42,11 @@ class BoolType implements Type {
         return other instanceof BoolType || other instanceof AnyType;
     }
 
+    public Type findSupertypeWith(Type other) {
+        return other instanceof BoolType ? BoolType.singleton
+                                         : AnyType.singleton;
+    }
+
     @Override
     public String toString() {
         return "Bool";
@@ -51,6 +61,11 @@ class IntType implements Type {
 
     public boolean consistentWith(Type other) {
         return other instanceof IntType || other instanceof AnyType;
+    }
+
+    public Type findSupertypeWith(Type other) {
+        return other instanceof IntType ? IntType.singleton
+                                        : AnyType.singleton;
     }
 
     @Override
@@ -69,6 +84,11 @@ class StringType implements Type {
         return other instanceof StringType || other instanceof AnyType;
     }
 
+    public Type findSupertypeWith(Type other) {
+        return other instanceof StringType ? StringType.singleton
+                                           : AnyType.singleton;
+    }
+
     @Override
     public String toString() {
         return "String";
@@ -83,6 +103,11 @@ class UnitType implements Type {
 
     public boolean consistentWith(Type other) {
         return other instanceof UnitType || other instanceof AnyType;
+    }
+
+    public Type findSupertypeWith(Type other) {
+        return other instanceof UnitType ? UnitType.singleton
+                                         : AnyType.singleton;
     }
 
     @Override
@@ -120,6 +145,27 @@ class ClosureType implements Type {
         }
         ClosureType that = (ClosureType)other;
         return arg.consistentWith(that.arg) && ret.consistentWith(that.ret);
+    }
+
+    public Type findSupertypeWith(Type other) {
+        if (!(other instanceof ClosureType)) {
+            return AnyType.singleton;
+        }
+        ClosureType that = (ClosureType)other;
+        return new ClosureType(
+                arg.findSupertypeWith(that.arg),
+                ret.findSupertypeWith(that.ret));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ClosureType)) {
+            return false;
+        }
+
+        ClosureType that = (ClosureType)other;
+
+        return arg.equals(that.arg) && ret.equals(that.ret);
     }
 
     @Override

--- a/src/edu/sjsu/stratagem/Type.java
+++ b/src/edu/sjsu/stratagem/Type.java
@@ -87,7 +87,7 @@ class UnitType implements Type {
 
     @Override
     public String toString() {
-        return "()";
+        return "Unit";
     }
 }
 

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -138,6 +138,6 @@ class UnitVal implements Value {
     }
     @Override
     public String toString() {
-        return "()";
+        return "unit";
     }
 }

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -17,6 +17,9 @@ public interface Value {
  * Boolean values.
  */
 class BoolVal implements Value {
+    public static final BoolVal trueSingleton = new BoolVal(true);
+    public static final BoolVal falseSingleton = new BoolVal(false);
+
     private boolean boolVal;
     public BoolVal(boolean b) { this.boolVal = b; }
     public Type getType() {

--- a/stratagemScripts/examples.strata
+++ b/stratagemScripts/examples.strata
@@ -1,5 +1,10 @@
 // Interesting examples
 
+let succ: Int -> Int = fn(n: Int): Int { n + 1 }
+in let anySucc: ? = succ
+in let anyTrue: ? = true
+in anySucc(anyTrue);
+
 let apply: (Int -> Int) -> Int -> Int =
     fn(f: Int -> Int): Int -> Int {
         fn(n: Int): Int {

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -83,6 +83,12 @@ public class CastTest {
     //   if (true) { identity } else { succ }
     // has type Int -> ?
     public void testSimpleFunctionIfCast() {
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, id, succ);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type intToAny = new ClosureType(IntType.singleton, AnyType.singleton);
+
+        assertEquals(intToAny, ifResultType);
     }
 
     @Test

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -29,7 +29,7 @@ public class CastTest {
                 "s",
                 StringType.singleton,
                 UnitType.singleton,
-                new ValueExpr(UnitVal.singleton));
+                ValueExpr.unitSingleton);
         FunctionAppExpr app = new FunctionAppExpr(f, n);
 
         app.typecheck(new TypeEnvironment());  // Insert cast that will fail.

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -31,7 +31,7 @@ public class CastTest {
     // Assert that
     //   if (true) { true } else { unit }
     // has type ?
-    public void testPrimitiveIfCast() {
+    public void testPrimitiveIfCast1() {
         IfExpr ifExpr = new IfExpr(
                 ValueExpr.trueSingleton,
                 ValueExpr.trueSingleton,
@@ -44,17 +44,104 @@ public class CastTest {
 
     @Test
     // Assert that
+    //   if (true) { true } else { <?>unit }
+    // has type ?
+    public void testPrimitiveIfCast2() {
+        IfExpr ifExpr = new IfExpr(
+                ValueExpr.trueSingleton,
+                ValueExpr.trueSingleton,
+                TestUtils.makeAny(UnitVal.singleton));
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+
+        assertEquals(AnyType.singleton, ifResultType);
+    }
+
+    @Test
+    // Assert that
+    //   let fn1: Int -> Unit = ... in
+    //   let fn2: Unit -> Unit = ... in
+    //   if (true) { fn1 } else { fn2 }
+    // has type ? -> Unit
+    public void testSimpleFunctionIfCast1() {
+        Expression fn1 = TestUtils.makeTrivialFn(IntType.singleton, UnitType.singleton);
+        Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, UnitType.singleton);
+
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type anyToUnit = new ClosureType(AnyType.singleton, UnitType.singleton);
+
+        assertEquals(anyToUnit, ifResultType);
+    }
+
+    @Test
+    // Assert that
+    //   let fn1: ? -> Unit = ... in
+    //   let fn2: Unit -> Unit = ... in
+    //   if (true) { fn1 } else { fn2 }
+    // has type ? -> Unit
+    public void testSimpleFunctionIfCast2() {
+        Expression fn1 = TestUtils.makeTrivialFn(AnyType.singleton, UnitType.singleton);
+        Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, UnitType.singleton);
+
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type anyToUnit = new ClosureType(AnyType.singleton, UnitType.singleton);
+
+        assertEquals(anyToUnit, ifResultType);
+    }
+
+    @Test
+    // Assert that
+    //   let fn1: Unit -> Int = ... in
+    //   let fn2: Unit -> Unit = ... in
+    //   if (true) { fn1 } else { fn2 }
+    // has type Unit -> ?
+    public void testSimpleFunctionIfCast3() {
+        Expression fn1 = TestUtils.makeTrivialFn(UnitType.singleton, IntType.singleton);
+        Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, UnitType.singleton);
+
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type unitToAny = new ClosureType(UnitType.singleton, AnyType.singleton);
+
+        assertEquals(unitToAny, ifResultType);
+    }
+
+    @Test
+    // Assert that
+    //   let fn1: Unit -> ? = ... in
+    //   let fn2: Unit -> Int = ... in
+    //   if (true) { fn1 } else { fn2 }
+    // has type Unit -> ?
+    public void testSimpleFunctionIfCast4() {
+        Expression fn1 = TestUtils.makeTrivialFn(UnitType.singleton, AnyType.singleton);
+        Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, UnitType.singleton);
+
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type unitToAny = new ClosureType(UnitType.singleton, AnyType.singleton);
+
+        assertEquals(unitToAny, ifResultType);
+    }
+
+    @Test
+    // Assert that
     //   let identity: ? -> ? = fn(x: ?): ? { x } in
     //   let succ: Int -> Int = fn(n: Int): Int { n + 1 } in
     //   if (true) { identity } else { succ }
-    // has type Int -> ?
-    public void testSimpleFunctionIfCast() {
+    // has type ? -> ?
+    public void testSimpleFunctionIfCast5() {
         IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, TestUtils.id, TestUtils.succ);
 
         Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
-        Type intToAny = new ClosureType(IntType.singleton, AnyType.singleton);
+        Type anyToAny = new ClosureType(AnyType.singleton, AnyType.singleton);
 
-        assertEquals(intToAny, ifResultType);
+        assertEquals(anyToAny, ifResultType);
     }
 
     @Test
@@ -62,7 +149,7 @@ public class CastTest {
     //   let fn1: String -> Int -> ? = ... in
     //   let fn2: Unit -> Int -> Int = ... in
     //   if (true) { fn1 } else { fn2 }
-    // has type ? -> Int -> Int
+    // has type ? -> Int -> ?
     public void testComplexFunctionIfCast() {
         Expression fn1 = TestUtils.makeTrivialFn(StringType.singleton, IntType.singleton, AnyType.singleton);
         Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, IntType.singleton, IntType.singleton);
@@ -70,12 +157,12 @@ public class CastTest {
         IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
 
         Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
-        Type anyToIntToInt = new ClosureType(
+        Type anyToIntToAny = new ClosureType(
                 AnyType.singleton,
                 new ClosureType(
                         IntType.singleton,
-                        IntType.singleton));
+                        AnyType.singleton));
 
-        assertEquals(anyToIntToInt, ifResultType);
+        assertEquals(anyToIntToAny, ifResultType);
     }
 }

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.*;
 
 public class CastTest {
 
-    // Produce an int value with type Any.
-    //   fn(n: Int): ? { val }
+    // Produce an int value with type Any, as in:
+    //   fn(n: Int): ? { n }(val)
     private Expression makeAny(int val) {
         FunctionDeclExpr f = new FunctionDeclExpr(
                 "n",
@@ -19,9 +19,10 @@ public class CastTest {
     }
 
     @Test
-    // let n: ? = 1
-    // in fn(s: String): Unit { unit }
-    //  throws StratagemCastException
+    // Assert that
+    //   let n: ? = 1 in
+    //   fn(s: String): Unit { unit }
+    // throws a StratagemCastException
     public void testApplicationCastException() {
         Expression n = makeAny(1);
         FunctionDeclExpr f = new FunctionDeclExpr(
@@ -39,5 +40,30 @@ public class CastTest {
             return;  // pass
         }
         assertTrue("Failed to throw StratagemCastException", false);
+    }
+
+    @Test
+    // Assert that
+    //   if (true) { 1 } else { unit }
+    // has type ?
+    public void testPrimitiveIfCast() {
+    }
+
+    @Test
+    // Assert that
+    //   let identity: ? -> ? = fn(x: ?): ? { x } in
+    //   let succ: Int -> Int = fn(n: Int): Int { n + 1 } in
+    //   if (true) { identity } else { succ }
+    // has type Int -> ?
+    public void testSimpleFunctionIfCast() {
+    }
+
+    @Test
+    // Assert that
+    //   let fn1: String -> Int -> ? = ... in
+    //   let fn2: Unit -> Int -> Int = ... in
+    //   if (true) { fn1 } else { fn2 }
+    // has type ? -> Int -> Int
+    public void testComplexFunctionIfCast() {
     }
 }

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -6,48 +6,14 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class CastTest {
-    // Produce an value with type Any, as in:
-    //   fn(x: ?): ? { x }(val)
-    // which has type
-    //   ?
-    // and which evaluates to
-    //   val
-    private static FunctionAppExpr makeAny(Value value) {
-        return new FunctionAppExpr(id, new ValueExpr(value));
-    }
-
-    private static FunctionAppExpr makeAny(int n) {
-        return makeAny(new IntVal(n));
-    }
-
-    // The identity function:
-    //   fn(x: ?): ? { x }
-    private static final FunctionDeclExpr id = new FunctionDeclExpr(
-            "x",
-            AnyType.singleton,
-            AnyType.singleton,
-            new VarExpr("x"));
-
-    // The successor function:
-    //   fn(n: Int): Int { n + 1 }
-    private static final FunctionDeclExpr succ = new FunctionDeclExpr(
-            "n",
-            IntType.singleton,
-            IntType.singleton,
-            new BinOpExpr(Op.ADD, new VarExpr("n"), new ValueExpr(new IntVal(1))));
-
     @Test
     // Assert that
     //   let n: ? = 1 in
     //   fn(s: String): Unit { unit }
     // throws a StratagemCastException
     public void testApplicationCastException() {
-        FunctionDeclExpr f = new FunctionDeclExpr(
-                "s",
-                StringType.singleton,
-                UnitType.singleton,
-                ValueExpr.unitSingleton);
-        Expression n = makeAny(1);
+        Expression f = TestUtils.makeTrivialFn(StringType.singleton, UnitType.singleton);
+        Expression n = TestUtils.makeAny(1);
         FunctionAppExpr app = new FunctionAppExpr(f, n);
 
         app.typecheck(new TypeEnvironment());  // Insert cast that will fail.
@@ -83,7 +49,7 @@ public class CastTest {
     //   if (true) { identity } else { succ }
     // has type Int -> ?
     public void testSimpleFunctionIfCast() {
-        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, id, succ);
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, TestUtils.id, TestUtils.succ);
 
         Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
         Type intToAny = new ClosureType(IntType.singleton, AnyType.singleton);

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -44,9 +44,17 @@ public class CastTest {
 
     @Test
     // Assert that
-    //   if (true) { 1 } else { unit }
+    //   if (true) { true } else { unit }
     // has type ?
     public void testPrimitiveIfCast() {
+        IfExpr ifExpr = new IfExpr(
+                ValueExpr.trueSingleton,
+                ValueExpr.trueSingleton,
+                ValueExpr.unitSingleton);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+
+        assertEquals(AnyType.singleton, ifResultType);
     }
 
     @Test

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -1,0 +1,43 @@
+package edu.sjsu.stratagem;
+
+import edu.sjsu.stratagem.exception.StratagemCastException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CastTest {
+
+    // Produce an int value with type Any.
+    //   fn(n: Int): ? { val }
+    private Expression makeAny(int val) {
+        FunctionDeclExpr f = new FunctionDeclExpr(
+                "n",
+                IntType.singleton,
+                AnyType.singleton,
+                new VarExpr("n"));
+        return new FunctionAppExpr(f, new ValueExpr(new IntVal(val)));
+    }
+
+    @Test
+    // let n: ? = 1
+    // in fn(s: String): Unit { unit }
+    //  throws StratagemCastException
+    public void testApplicationCastException() {
+        Expression n = makeAny(1);
+        FunctionDeclExpr f = new FunctionDeclExpr(
+                "s",
+                StringType.singleton,
+                UnitType.singleton,
+                new ValueExpr(UnitVal.singleton));
+        FunctionAppExpr app = new FunctionAppExpr(f, n);
+
+        app.typecheck(new TypeEnvironment());  // Insert cast that will fail.
+
+        try {
+            app.evaluate(new ValueEnvironment());
+        } catch (StratagemCastException e) {
+            return;  // pass
+        }
+        assertTrue("Failed to throw StratagemCastException", false);
+    }
+}

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -64,5 +64,18 @@ public class CastTest {
     //   if (true) { fn1 } else { fn2 }
     // has type ? -> Int -> Int
     public void testComplexFunctionIfCast() {
+        Expression fn1 = TestUtils.makeTrivialFn(StringType.singleton, IntType.singleton, AnyType.singleton);
+        Expression fn2 = TestUtils.makeTrivialFn(UnitType.singleton, IntType.singleton, IntType.singleton);
+
+        IfExpr ifExpr = new IfExpr(ValueExpr.trueSingleton, fn1, fn2);
+
+        Type ifResultType = ifExpr.typecheck(new TypeEnvironment());
+        Type anyToIntToInt = new ClosureType(
+                AnyType.singleton,
+                new ClosureType(
+                        IntType.singleton,
+                        IntType.singleton));
+
+        assertEquals(anyToIntToInt, ifResultType);
     }
 }

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -36,7 +36,7 @@ public class ExpressionTest {
     @Test
     public void testIfTrueExpr() {
         ValueEnvironment env = new ValueEnvironment();
-        IfExpr ife = new IfExpr(new ValueExpr(new BoolVal(true)),
+        IfExpr ife = new IfExpr(ValueExpr.trueSingleton,
                 new ValueExpr(new IntVal(1)),
                 new ValueExpr(new IntVal(2)));
         IntVal iv = (IntVal) ife.evaluate(env);
@@ -46,7 +46,7 @@ public class ExpressionTest {
     @Test
     public void testIfFalseExpr() {
         ValueEnvironment env = new ValueEnvironment();
-        IfExpr ife = new IfExpr(new ValueExpr(new BoolVal(false)),
+        IfExpr ife = new IfExpr(ValueExpr.falseSingleton,
                 new ValueExpr(new IntVal(1)),
                 new ValueExpr(new IntVal(2)));
         IntVal iv = (IntVal) ife.evaluate(env);

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -2,10 +2,6 @@ package edu.sjsu.stratagem;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import edu.sjsu.stratagem.exception.StratagemCastException;
 import edu.sjsu.stratagem.exception.StratagemException;
 import org.junit.Test;
 
@@ -179,39 +175,5 @@ public class ExpressionTest {
                 new ValueExpr(alice));
         Value v = outerApp.evaluate(env);
         assertEquals(v, alice);
-    }
-
-    // Produce an int value with type Any.
-    //   fn(n: Int): ? { val }
-    private Expression makeAny(int val) {
-        FunctionDeclExpr f = new FunctionDeclExpr(
-                "n",
-                IntType.singleton,
-                AnyType.singleton,
-                new VarExpr("n"));
-        return new FunctionAppExpr(f, new ValueExpr(new IntVal(val)));
-    }
-
-    @Test
-    // let n: ? = 1
-    // in fn(s: String): () { () }
-    //  throws StratagemCastException
-    public void testApplicationCastException() {
-        Expression n = makeAny(1);
-        FunctionDeclExpr f = new FunctionDeclExpr(
-                "s",
-                StringType.singleton,
-                UnitType.singleton,
-                new ValueExpr(UnitVal.singleton));
-        FunctionAppExpr app = new FunctionAppExpr(f, n);
-
-        app.typecheck(new TypeEnvironment());  // Insert cast that will fail.
-
-        try {
-            app.evaluate(new ValueEnvironment());
-        } catch (StratagemCastException e) {
-            return;  // pass
-        }
-        assertTrue("Failed to throw StratagemCastException", false);
     }
 }

--- a/testSrc/edu/sjsu/stratagem/TestUtils.java
+++ b/testSrc/edu/sjsu/stratagem/TestUtils.java
@@ -1,0 +1,71 @@
+package edu.sjsu.stratagem;
+
+class TestUtils {
+    // Produce an value with type Any, as in:
+    //   fn(x: ?): ? { x }(val)
+    // which has type
+    //   ?
+    // and which evaluates to
+    //   val
+    static FunctionAppExpr makeAny(Value value) {
+        return new FunctionAppExpr(id, new ValueExpr(value));
+    }
+
+    static FunctionAppExpr makeAny(int n) {
+        return makeAny(new IntVal(n));
+    }
+
+    // The identity function:
+    //   fn(x: ?): ? { x }
+    static final FunctionDeclExpr id = new FunctionDeclExpr(
+            "x",
+            AnyType.singleton,
+            AnyType.singleton,
+            new VarExpr("x"));
+
+    // The successor function:
+    //   fn(n: Int): Int { n + 1 }
+    static final FunctionDeclExpr succ = new FunctionDeclExpr(
+            "n",
+            IntType.singleton,
+            IntType.singleton,
+            new BinOpExpr(Op.ADD, new VarExpr("n"), new ValueExpr(new IntVal(1))));
+
+    // Produces an expression of the type:
+    //   arg -> ret
+    static Expression makeTrivialFn(Type arg, Type ret) {
+        Type fnType = new ClosureType(arg, ret);
+        return makeTrivialExpression(fnType);
+    }
+
+    // Produces an expression of the type:
+    //   arg -> ret1 -> ret2
+    static Expression makeTrivialFn(Type arg, Type ret1, Type ret2) {
+        Type fnType = new ClosureType(arg, new ClosureType(ret1, ret2));
+        return makeTrivialExpression(fnType);
+    }
+
+    // Produces the simplest possible expression of the requested type.
+    static Expression makeTrivialExpression(Type type) {
+        if (type instanceof AnyType) {
+            return makeAny(UnitVal.singleton);
+        } else if (type instanceof BoolType) {
+            return ValueExpr.trueSingleton;
+        } else if (type instanceof ClosureType) {
+            ClosureType closureType = (ClosureType) type;
+            return new FunctionDeclExpr(
+                    "x",
+                    closureType.getArgType(),
+                    closureType.getReturnType(),
+                    makeTrivialExpression(closureType.getReturnType()));
+        } else if (type instanceof IntType) {
+            return new ValueExpr(new IntVal(0));
+        } else if (type instanceof StringType) {
+            return new ValueExpr(new StringVal(""));
+        } else if (type instanceof UnitType) {
+            return ValueExpr.unitSingleton;
+        } else {
+            throw new RuntimeException("I don't know how to make a value of that type yet!");
+        }
+    }
+}


### PR DESCRIPTION
When an if-expression returns values of different types from its left and right branches, it's not necessarily obvious what type the if-expression should evaluate to. We might ask the following questions:

- Should the if-expression be rejected as an error?
- Or, should the if-expression return some type common to the two branches?

This PR takes the second choice. It makes if-expressions return the type that is the lowest common supertype of both branches.

This is consistent with TypeScript's decision on the same matter.

Six new tests in the CastTest class have been written to test this behavior.

Fixes #20.