### PR TITLE
Remove function return type annotations

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -71,7 +71,7 @@ seq: expr (SEPARATOR expr)* ;
 
 expr: LPAREN expr RPAREN                                                          # parens
     | expr args                                                                   # functionApp
-    | FUNCTION params (COLON type)? LBRACE seq RBRACE                             # functionDecl
+    | FUNCTION params LBRACE seq RBRACE                                           # functionDecl
     | LIT_INT                                                                     # int
     | LIT_BOOL                                                                    # bool
     | LIT_STRING                                                                  # string

--- a/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
+++ b/src/edu/sjsu/stratagem/ExpressionBuilderVisitor.java
@@ -75,16 +75,13 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
     @Override
     public Expression visitFunctionDecl(StratagemParser.FunctionDeclContext ctx) {
         StratagemParser.TypeContext paramTypeContext = ctx.params().type();
-        StratagemParser.TypeContext returnTypeContext = ctx.type();
 
         String paramName = ctx.params().ID().getText();
         Type paramType = paramTypeContext == null ? AnyType.singleton
                                                   : parseType(paramTypeContext);
-        Type returnType = returnTypeContext == null ? AnyType.singleton
-                                                    : parseType(returnTypeContext);
         Expression body = visit(ctx.seq());
 
-        return new FunctionDeclExpr(paramName, paramType, returnType, body);
+        return new FunctionDeclExpr(paramName, paramType, body);
     }
 
     @Override
@@ -117,7 +114,7 @@ public class ExpressionBuilderVisitor extends StratagemBaseVisitor<Expression>{
         Type paramType = typeContext == null ? AnyType.singleton
                                              : parseType(typeContext);
 
-        FunctionDeclExpr implicitDecl = new FunctionDeclExpr(id, paramType, null, body);
+        FunctionDeclExpr implicitDecl = new FunctionDeclExpr(id, paramType, body);
         return new FunctionAppExpr(implicitDecl, value);
     }
 

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -66,8 +66,7 @@ class ClosureVal implements Value {
 
     public String toString() {
         StringBuilder s = new StringBuilder("function(");
-        String sep = "";
-        s.append(sep).append(paramName).append(": ").append(paramType);
+        s.append(paramName).append(": ").append(paramType);
         s.append("): ").append(returnType).append(" {...}");
 
         return s.toString();

--- a/stratagemScripts/cast.strata
+++ b/stratagemScripts/cast.strata
@@ -1,0 +1,4 @@
+let succ: Int -> Int = fn(n: Int) { n + 1 }
+in let anySucc: ? = succ
+in let anyTrue: ? = true
+in anySucc(anyTrue)  // Throws exception

--- a/stratagemScripts/examples.strata
+++ b/stratagemScripts/examples.strata
@@ -1,18 +1,13 @@
 // Interesting examples
 
-let succ: Int -> Int = fn(n: Int): Int { n + 1 }
-in let anySucc: ? = succ
-in let anyTrue: ? = true
-in anySucc(anyTrue);
-
 let apply: (Int -> Int) -> Int -> Int =
-    fn(f: Int -> Int): Int -> Int {
-        fn(n: Int): Int {
+    fn(f: Int -> Int) {
+        fn(n: Int) {
             f(n)
         }
     }
-in let plusOne: Int -> Int = fn(n: Int): Int { n + 1 }
-in apply(plusOne)(2) == 3;
+in let succ: Int -> Int = fn(n: Int) { n + 1 }
+in apply(succ)(2) == 3;  // True
 
 let fix =
     fn(f) {
@@ -27,8 +22,8 @@ let fix =
         })
     }
 in let fix_factorial: (Int -> Int) -> Int -> Int =
-    fn(f: Int -> Int): Int -> Int {
-        fn(n: Int): Int {
+    fn(f: Int -> Int) {
+        fn(n: Int) {
             if (n == 0) {
                 1
             } else {
@@ -36,4 +31,5 @@ in let fix_factorial: (Int -> Int) -> Int -> Int =
             }
         }
     }
-in fix(fix_factorial)(4)  // 24
+in let factorial: Int -> Int = fix(fix_factorial)
+in factorial(4)  // 24

--- a/stratagemScripts/expressions.strata
+++ b/stratagemScripts/expressions.strata
@@ -8,22 +8,20 @@ true;
 unit;
 
 // Function declaration
-fn(n: Int): Int { 1 };
-fn(n): Int { 1 };
 fn(n: Int) { 1 };
 fn(n) { 1 };
 
 // Function application
-fn(n: Int): Int { 1 }(2);
+fn(n: Int) { 1 }(2);
 
-fn(x: Int): Int -> Int {
-    fn(y: Int): Int {
+fn(x: Int) {
+    fn(y: Int) {
         1
     }
 }(2)(3);
 
 // Id
-fn(n: Int): Int { n }(1);
+fn(n: Int) { n }(1);
 
 // Let
 let one: Int = 1 in 2;

--- a/stratagemScripts/print.strata
+++ b/stratagemScripts/print.strata
@@ -1,5 +1,5 @@
 print("string");  // string
 print(true);  // boolean
-print(fn(n: Int): Int { n + 1 });  // closure
+print(fn(n: Int) { n + 1 });  // closure
 print(5 - 5);  // integer
 print(unit)  // unit

--- a/testSrc/edu/sjsu/stratagem/CastTest.java
+++ b/testSrc/edu/sjsu/stratagem/CastTest.java
@@ -9,7 +9,7 @@ public class CastTest {
     @Test
     // Assert that
     //   let n: ? = 1 in
-    //   fn(s: String): Unit { unit }
+    //   fn(s: String) { unit }
     // throws a StratagemCastException
     public void testApplicationCastException() {
         Expression f = TestUtils.makeTrivialFn(StringType.singleton, UnitType.singleton);
@@ -131,8 +131,8 @@ public class CastTest {
 
     @Test
     // Assert that
-    //   let identity: ? -> ? = fn(x: ?): ? { x } in
-    //   let succ: Int -> Int = fn(n: Int): Int { n + 1 } in
+    //   let identity: ? -> ? = fn(x: ?) { x } in
+    //   let succ: Int -> Int = fn(n: Int) { n + 1 } in
     //   if (true) { identity } else { succ }
     // has type ? -> ?
     public void testSimpleFunctionIfCast5() {

--- a/testSrc/edu/sjsu/stratagem/ExpressionTest.java
+++ b/testSrc/edu/sjsu/stratagem/ExpressionTest.java
@@ -93,9 +93,9 @@ public class ExpressionTest {
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr f = new FunctionDeclExpr(
                 "x",
-                null,
-                null,
+                AnyType.singleton,
                 new VarExpr("x"));
+        f.typecheck(new TypeEnvironment());
         Expression arg = new ValueExpr(new IntVal(321));
         FunctionAppExpr app = new FunctionAppExpr(f, arg);
         assertEquals(new IntVal(321), app.evaluate(env));
@@ -110,14 +110,13 @@ public class ExpressionTest {
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
                 "unused",
-                null,
-                null,
+                StringType.singleton,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
                 "name",
-                null,
-                null,
+                StringType.singleton,
                 new FunctionAppExpr(innerDecl, new ValueExpr(bob)));
+        outerDecl.typecheck(new TypeEnvironment());
 
         FunctionAppExpr outerApp = new FunctionAppExpr(outerDecl, new ValueExpr(alice));
         Value v = outerApp.evaluate(env);
@@ -133,14 +132,13 @@ public class ExpressionTest {
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
                 "name",
-                null,
-                null,
+                StringType.singleton,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
                 "name",
-                null,
-                null,
+                StringType.singleton,
                 new FunctionAppExpr(innerDecl, new ValueExpr(bob)));
+        outerDecl.typecheck(new TypeEnvironment());
 
         FunctionAppExpr outerApp = new FunctionAppExpr(
                 outerDecl,
@@ -158,17 +156,16 @@ public class ExpressionTest {
         ValueEnvironment env = new ValueEnvironment();
         FunctionDeclExpr innerDecl = new FunctionDeclExpr(
                 "name",
-                null,
-                null,
+                StringType.singleton,
                 new VarExpr("name"));
         FunctionDeclExpr outerDecl = new FunctionDeclExpr(
                 "name",
-                null,
-                null,
+                StringType.singleton,
                 new SeqExpr(new Expression[] {
                         new FunctionAppExpr(innerDecl, new ValueExpr(bob)),
                         new VarExpr("name")
                 }));
+        outerDecl.typecheck(new TypeEnvironment());
 
         FunctionAppExpr outerApp = new FunctionAppExpr(
                 outerDecl,

--- a/testSrc/edu/sjsu/stratagem/TestUtils.java
+++ b/testSrc/edu/sjsu/stratagem/TestUtils.java
@@ -2,7 +2,7 @@ package edu.sjsu.stratagem;
 
 class TestUtils {
     // Produce an value with type Any, as in:
-    //   fn(x: ?): ? { x }(val)
+    //   fn(x: ?) { x }(val)
     // which has type
     //   ?
     // and which evaluates to
@@ -16,18 +16,16 @@ class TestUtils {
     }
 
     // The identity function:
-    //   fn(x: ?): ? { x }
+    //   fn(x: ?) { x }
     static final FunctionDeclExpr id = new FunctionDeclExpr(
             "x",
-            AnyType.singleton,
             AnyType.singleton,
             new VarExpr("x"));
 
     // The successor function:
-    //   fn(n: Int): Int { n + 1 }
+    //   fn(n: Int) { n + 1 }
     static final FunctionDeclExpr succ = new FunctionDeclExpr(
             "n",
-            IntType.singleton,
             IntType.singleton,
             new BinOpExpr(Op.ADD, new VarExpr("n"), new ValueExpr(new IntVal(1))));
 
@@ -56,7 +54,6 @@ class TestUtils {
             return new FunctionDeclExpr(
                     "x",
                     closureType.getArgType(),
-                    closureType.getReturnType(),
                     makeTrivialExpression(closureType.getReturnType()));
         } else if (type instanceof IntType) {
             return new ValueExpr(new IntVal(0));


### PR DESCRIPTION
Function return types are now inferred from the type of the body expression.

- E.g., succ is now written: fn(n: Int) { n + 1 }
- Completely removes support for user-annotated return types.
- Fixes some places we were incorrectly skipping typechecking.
- Creates a new cast.strata file for the cast failure example.
- It is now mandatory to fill in the parameter type for functions. (Affects a few tests.)
- It is now mandatory to typecheck functions before evaluating them so that they can get a chance to calculate their return type. (Also affects a few tests.)

This is also nice because let-bindings were already doing this for a month or two, and now functions have caught up. We should once again be able to describe let-bindings as merely syntactic sugar for a function decl & function app. 🎉