### PR TITLE
Add mutable references to the language

### DIFF
--- a/Stratagem.g4
+++ b/Stratagem.g4
@@ -8,6 +8,7 @@ FUNCTION : 'fn' ;
 IF       : 'if' ;
 ELSE     : 'else' ;
 LET      : 'let' ;
+REF      : 'ref' ;
 
 // Literals
 LIT_UNIT   : 'unit' ;
@@ -21,6 +22,7 @@ TYPE_UNIT      : 'Unit' ;
 TYPE_INT       : 'Int' ;
 TYPE_BOOL      : 'Bool' ;
 TYPE_STRING    : 'String' ;
+TYPE_REF       : 'Ref' ;
 TYPE_FUN       : '->' ;
 TYPE_ANY       : '?' ;
 
@@ -47,8 +49,10 @@ LPAREN : '(' ;
 RPAREN : ')' ;
 LBRACE : '{' ;
 RBRACE : '}' ;
-ASSIGN : '=' ;
+BIND : '=' ;
 IN : 'in' ;
+DEREF : '!' ;
+ASSIGN : '<-' ;
 
 // Identifiers
 ID : [a-zA-Z_] [a-zA-Z0-9_]* ;
@@ -72,13 +76,16 @@ seq: expr (SEPARATOR expr)* ;
 expr: LPAREN expr RPAREN                                                          # parens
     | expr args                                                                   # functionApp
     | FUNCTION params LBRACE seq RBRACE                                           # functionDecl
+    | REF expr                                                                    # ref
+    | DEREF expr                                                                  # deref
+    | expr ASSIGN expr                                                            # assign
     | LIT_INT                                                                     # int
     | LIT_BOOL                                                                    # bool
     | LIT_STRING                                                                  # string
     | LIT_UNIT                                                                    # unit
     | ID                                                                          # id
     | IF LPAREN expr RPAREN LBRACE seq RBRACE ELSE LBRACE seq RBRACE              # if
-    | LET ID (COLON type)? ASSIGN expr IN expr                                    # let
+    | LET ID (COLON type)? BIND expr IN expr                                      # let
     | expr op=( ADD | SUB | MUL | DIV | MOD | GT | GE | LT | LE | EQ | NE ) expr  # binOp
     | PRINT args                                                                  # print
     ;
@@ -91,7 +98,9 @@ args: LPAREN expr RPAREN
 
 type_prim : TYPE_INT | TYPE_BOOL | TYPE_STRING | TYPE_UNIT | TYPE_ANY ;
 
+type_ref  : TYPE_REF type ;
+
 //          (domain                            ) TYPE_FUN codomain ;
 type_fun  : (type_prim | LPAREN type_fun RPAREN) TYPE_FUN type ;
 
-type      : type_prim | type_fun ;
+type      : type_prim | type_ref | type_fun ;

--- a/src/edu/sjsu/stratagem/Value.java
+++ b/src/edu/sjsu/stratagem/Value.java
@@ -128,6 +128,47 @@ class IntVal implements Value {
 }
 
 /**
+ * Reference cells.
+ */
+class RefVal implements Value {
+    private Value value;
+
+    public RefVal(Value value) {
+        assert(value != null);
+
+        this.value = value;
+    }
+
+    public Value dereference() {
+        return value;
+    }
+
+    public void assign(Value value) {
+        assert(value != null);
+
+        Type oldType = this.value.getType();
+        Type newType = value.getType();
+        assert(oldType.equals(newType));
+
+        this.value = value;
+    }
+
+    public Type getType() {
+        return new RefType(value.getType());
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        return this == that;
+    }
+
+    @Override
+    public String toString() {
+        return "ref " + value;
+    }
+}
+
+/**
  * Strings.
  */
 class StringVal implements Value {

--- a/stratagemScripts/expressions.strata
+++ b/stratagemScripts/expressions.strata
@@ -7,6 +7,11 @@ true;
 "three";
 unit;
 
+// References
+ref 1;
+!ref 1;
+ref 1 <- 2;
+
 // Function declaration
 fn(n: Int) { 1 };
 fn(n) { 1 };

--- a/stratagemScripts/print.strata
+++ b/stratagemScripts/print.strata
@@ -2,4 +2,5 @@ print("string");  // string
 print(true);  // boolean
 print(fn(n: Int) { n + 1 });  // closure
 print(5 - 5);  // integer
+print(ref true);  // reference
 print(unit)  // unit

--- a/stratagemScripts/references.strata
+++ b/stratagemScripts/references.strata
@@ -1,0 +1,5 @@
+let r: Ref Int = ref 1 in
+let a = print(!r) in  // prints 1
+let b = r <- 2 in
+let c = print(!r) in  // prints 2
+unit


### PR DESCRIPTION
This PR adds references to the language with the same syntax and semantics as given by Siek in his  “Gradual Typing for Functional Languages.”

### The syntax

```
ref 1         // Create a Ref Int value that initially holds the Int value 1 in its cell.
!(ref 1)      // Dereference a Ref value.
(ref 1) <- 2  // Assign a new value to a Ref value.
```

- The associativity in the parsing is such that all of the parentheses above are redundant. I included them merely for clarity.

- The type “Ref” is capitalized while values are produced with a lowercase “ref” operator.

### The typing

- References are *invariant* with respect to their cell type. That is, you cannot bind a `Ref Int` to a variable with ascribed type `Ref ?`, which is a little surprising. Siek discusses how, if this were allowed, type safety would be violated.†

### The casting

- The casting rules for references are *very* similar to our casting rules for functions because they are both data structures that are parameterized by other types (i.e., they both have the type variable T as in `Ref <T>` and `fn(<T1>): <T2> { ... }`) and they both contain sub-`Value`s. This shared structure leads to similar casts.

### The semantics

- In assignment expressions, the left-hand side is evaluated before the right-hand side.

### Implementation details

- In the literature, references are a “location” that points into a “store.” Our implementation here, however, simply uses `RefVal` objects that have a single `Value` member variable. In effect, the member variable is an object reference (location) which points into the Java heap (store). This works well because our implementation language Java has garbage collection.

### Siek's syntax, typing rules, and cast rules

#### Syntax

![screen shot 2017-09-20 at 2 44 02 am](https://user-images.githubusercontent.com/107998/30637654-d6e107de-9dad-11e7-93bb-87fa3348983b.png)

#### Typing rules

![screen shot 2017-09-20 at 2 43 11 am](https://user-images.githubusercontent.com/107998/30637669-e33caee8-9dad-11e7-9f90-a11803c65525.png)

#### Cast rules

![screen shot 2017-09-20 at 2 43 39 am](https://user-images.githubusercontent.com/107998/30637680-e8989a28-9dad-11e7-8525-cb046191e371.png)

---

† The following program, if allowed, would violate type safety:

```
let r1 = ref (fn(x) { x }) in
let r2: Ref ? = r1 in
    r2 <- 1;
    !r1(2)
```

Siek describes: “The reference r1 is initialized with a function, and then r2 is aliased to r1, using the covariance to allow the change in type to Ref ?. We can then write an integer into the cell pointed to by r2 (and by r1). The subsequent attempt to apply the contents of r1 as if it were a function fails at runtime.”